### PR TITLE
Add Launchory to Product & Startup Directories

### DIFF
--- a/Communities.md
+++ b/Communities.md
@@ -83,6 +83,7 @@ Sites that list startups for long-term visibility.
 - **[Capterra](https://www.capterra.com/)** – Review platform for software businesses.
 - **[GetApp](https://www.getapp.com/)** – Business software directory.
 - **[SaaSworthy](https://www.saasworthy.com/)** – SaaS comparison and reviews.
+- **[Launchory](https://www.launchory.app/)** – Free startup directory with a public profile page and dofollow link on approval.
 
 ## 📈 Marketing & Growth Resources
 


### PR DESCRIPTION
Adds one entry to the **Product & Startup Directories** section of `Communities.md`, matching the existing single-line format exactly.

- **[Launchory](https://www.launchory.app/)** – Free startup directory with a public profile page and dofollow link on approval.

It fits that section rather than the launch platforms one: listings are permanent profile pages for long-term visibility, not a one-day launch. Submission is free at https://www.launchory.app/submit.

Happy to move it to a different section or reword the description if you'd prefer.